### PR TITLE
Fix style path for Reel page

### DIFF
--- a/pages/reel.tsx
+++ b/pages/reel.tsx
@@ -9,7 +9,7 @@ import { globalProps } from "lib/data/globalProps";
 import { reelPage } from "lib/data/reelPage";
 import { StaticProps } from "types";
 
-import styles from "styles/projects/Detail.module.css";
+import styles from "styles/Reel.module.css";
 
 export const getStaticProps = async () => {
   const global = await globalProps();
@@ -27,7 +27,7 @@ export const getStaticProps = async () => {
   };
 };
 
-export default function ProjectDetail({
+export default function Reel({
   reelUrl,
   reelCoverImage,
   description,


### PR DESCRIPTION
The reel page was referencing the wrong stylesheet, which broke it when the project detail styles changed. Fixed the reference as well as bad naming of the default export.